### PR TITLE
Fix for missing hits into cache

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -5,7 +5,8 @@ jobs:
     name: agda2scheme
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checks-out repository
+        uses: actions/checkout@v4
 
       - name: Set up GHC
         uses: haskell-actions/setup@v2
@@ -34,14 +35,14 @@ jobs:
 
       - name: Install dependencies
         # If we had an exact cache hit, the dependencies will be up to date.
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: cabal build all --only-dependencies
 
       # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
       - name: Save cached dependencies
         uses: actions/cache/save@v3
         # If we had an exact cache hit, trying to save the cache would error because of key clash.
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         with:
           path: ${{ steps.setup.outputs.cabal-store }}
           key: ${{ steps.cache.outputs.cache-primary-key }}


### PR DESCRIPTION
You can see in history of running actions, that [cache was missed](https://github.com/lemastero/agda2scheme/actions/runs/6938126168/job/18873377280):
```text
Run actions/cache/restore@v3
  with:
    path: /home/runner/.cabal/store
    key: Linux-ghc-9.0.[2](https://github.com/lemastero/agda2scheme/actions/runs/6938126168/job/18873377280#step:5:2)-cabal-[3](https://github.com/lemastero/agda2scheme/actions/runs/6938126168/job/18873377280#step:5:3).10.2.0-plan-5c8be[4](https://github.com/lemastero/agda2scheme/actions/runs/6938126168/job/18873377280#step:5:4)82f2[5](https://github.com/lemastero/agda2scheme/actions/runs/6938126168/job/18873377280#step:5:5)b20f5c486edf18a89ecc131f2c860f730e282950ae5dea2b2a95b
    restore-keys: Linux-ghc-9.0.2-cabal-3.10.2.0-
    enableCrossOsArchive: false
    fail-on-cache-miss: false
    lookup-only: false
  env:
    key: Linux-ghc-9.0.2-cabal-3.10.2.0
Cache not found for input keys: Linux-ghc-9.0.2-cabal-3.10.2.0-plan-5c8be482f25b20f5c48[6](https://github.com/lemastero/agda2scheme/actions/runs/6938126168/job/18873377280#step:5:6)edf18a89ecc131f2c860f[7](https://github.com/lemastero/agda2scheme/actions/runs/6938126168/job/18873377280#step:5:7)30e2[8](https://github.com/lemastero/agda2scheme/actions/runs/6938126168/job/18873377280#step:5:8)2[9](https://github.com/lemastero/agda2scheme/actions/runs/6938126168/job/18873377280#step:5:9)50ae5dea2b2a95b, Linux-ghc-9.0.2-cabal-3.[10](https://github.com/lemastero/agda2scheme/actions/runs/6938126168/job/18873377280#step:5:10).2.0-
```
even though it should hit as this was build for PR merged into main branch (and it was build on PR).

Build for this PR says:
```text
Run actions/cache/restore@v3
  with:
    path: /home/runner/.cabal/store
    key: Linux-ghc-9.0.[2](https://github.com/lemastero/agda2scheme/actions/runs/6938650337/job/18874718284#step:5:2)-cabal-[3](https://github.com/lemastero/agda2scheme/actions/runs/6938650337/job/18874718284#step:5:3).10.2.0-plan-5c8be[4](https://github.com/lemastero/agda2scheme/actions/runs/6938650337/job/18874718284#step:5:4)82f2[5](https://github.com/lemastero/agda2scheme/actions/runs/6938650337/job/18874718284#step:5:5)b20f5c486edf18a89ecc131f2c860f730e282950ae5dea2b2a95b
    restore-keys: Linux-ghc-9.0.2-cabal-3.10.2.0-
    enableCrossOsArchive: false
    fail-on-cache-miss: false
    lookup-only: false
  env:
    key: Linux-ghc-9.0.2-cabal-3.10.2.0
Cache Size: ~72 MB (75955227 B)
/usr/bin/tar -xf /home/runner/work/_temp/aa02298[6](https://github.com/lemastero/agda2scheme/actions/runs/6938650337/job/18874718284#step:5:6)-9fd5-4536-9f15-[7](https://github.com/lemastero/agda2scheme/actions/runs/6938650337/job/18874718284#step:5:7)f0ca3c12[8](https://github.com/lemastero/agda2scheme/actions/runs/6938650337/job/18874718284#step:5:8)7f/cache.tzst -P -C /home/runner/work/agda2scheme/agda2scheme --use-compress-program unzstd
Received 75[9](https://github.com/lemastero/agda2scheme/actions/runs/6938650337/job/18874718284#step:5:9)55227 of 75955227 ([10](https://github.com/lemastero/agda2scheme/actions/runs/6938650337/job/18874718284#step:5:10)0.0%), 72.4 MBs/sec
Cache restored successfully
Cache restored from key: Linux-ghc-9.0.2-cabal-3.10.2.0-plan-5c8be482f25b20f5c486edf18a89ecc[13](https://github.com/lemastero/agda2scheme/actions/runs/6938650337/job/18874718284#step:5:14)1f2c860f730e282950ae5dea2b2a95b
```
also no new cache was created in [catches view on GH](https://github.com/lemastero/agda2scheme/actions/caches).